### PR TITLE
Fix(wxh): Fix the bug in function get_parameters

### DIFF
--- a/fling/utils/torch_utils.py
+++ b/fling/utils/torch_utils.py
@@ -88,14 +88,15 @@ def get_parameters(model: nn.Module, parameter_args: dict, return_dict: bool = F
 
     if not return_dict:
         res = []
-        for key, param in model.named_parameters():
+        for key in model.state_dict().keys():
             if key in use_keys:
-                res.append(param)
+                res.append(model.state_dict()[key])
     else:
         res = {}
-        for key, param in model.named_parameters():
+        for key in model.state_dict().keys():
             if key in use_keys:
-                res[key] = param
+                res[key] = model.state_dict()[key]
+
     return res
 
 


### PR DESCRIPTION
Fix the bug in function 'get_parameters' in 'torch_utils.py'. In the pre-fix version, traversing parameters with 'named_parameters' discard the 'running_mean' and 'running_var' of the BN layers.